### PR TITLE
add humanmade mark to readme while respecting user's colour scheme preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Hi friends, I'd like to introduce you to a small project I've made.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="/docs/white-logo.svg">
+  <source media="(prefers-color-scheme: light)" srcset="/docs/black-logo.svg">
+  <img alt="Humanmade mark." src="/docs/black-logo.svg">
+</picture>
+
 The Humanmade mark, here, is something I will be attaching to any works of mine that were mostly made by me or my friends, not by generative tools like GPT. I've built this website to freely share the high-resolution black or white versions of the logo available with you, which you can download and attach to your own projects if you'd like to make the same statement.
 I've made the following video to try to make my reasons for making this clear, but it's simple:
 


### PR DESCRIPTION
While this doesn't resolve https://github.com/0atman/HumanMadeMark-com/issues/2, it gets us a little closer to having automatic dark/light-mode friendly logo on the readme.

Attached a screenshot to demonstrate with GitHub's themes: Light default, Dark dimmed, and Dark default.

![image](https://github.com/0atman/HumanMadeMark-com/assets/19497993/46c715b5-2722-448c-b981-267742e83daf)
