### PR TITLE
Update README.md to use automatically themed header image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 Hi friends, I'd like to introduce you to a small project I've made.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/docs/white-logo.svg">
-  <source media="(prefers-color-scheme: light)" srcset="/docs/black-logo.svg">
-  <img alt="Humanmade mark." src="/docs/black-logo.svg">
-</picture>
+![](docs/automatic-logo.svg)
 
 The Humanmade mark, here, is something I will be attaching to any works of mine that were mostly made by me or my friends, not by generative tools like GPT. I've built this website to freely share the high-resolution black or white versions of the logo available with you, which you can download and attach to your own projects if you'd like to make the same statement.
 I've made the following video to try to make my reasons for making this clear, but it's simple:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Hi friends, I'd like to introduce you to a small project I've made.
 
-![](docs/automatic-logo.svg)
+![Human Made Mark Image](docs/automatic-logo.svg)
 
 The Humanmade mark, here, is something I will be attaching to any works of mine that were mostly made by me or my friends, not by generative tools like GPT. I've built this website to freely share the high-resolution black or white versions of the logo available with you, which you can download and attach to your own projects if you'd like to make the same statement.
 I've made the following video to try to make my reasons for making this clear, but it's simple:


### PR DESCRIPTION
I'm never a fan of putting HTML in Markdown as it defeats the Human-readability, since there's now an option to use a single image for both light and dark mode, it makes sense to use it in the README for the project.

**Dark Default Theme**

![image](https://github.com/user-attachments/assets/27889353-8bf0-4b6d-bf32-b700013cc3b3)

**Light Default Theme**

![image](https://github.com/user-attachments/assets/269ead05-fe11-479f-a90e-1f0f30c4f9db)
